### PR TITLE
Updates metadata

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -16,24 +16,13 @@ versions:
           - source: github.com/cloud-native-toolkit/terraform-tools-gitops.git
             version: ">= 1.1.0"
       - id: cluster
-        refs:
-          - source: github.com/ibm-garage-cloud/terraform-ibm-container-platform
-            version: ">= 1.7.0"
-          - source: github.com/ibm-garage-cloud/terraform-ibm-ocp-vpc
-            version: ">= 1.0.0"
-          - source: github.com/ibm-garage-cloud/terraform-k8s-ocp-cluster
-            version: ">= 2.0.0"
+        refs: []
+        interface: github.com/cloud-native-toolkit/garage-terraform-modules#cluster
+        optional: true
       - id: namespace
         refs:
           - source: github.com/cloud-native-toolkit/terraform-gitops-namespace.git
             version: ">= 1.0.0"
-      - id: argocd-bootstrap
-        refs:
-          - source: github.com/cloud-native-toolkit/terraform-tools-argocd-bootstrap.git
-            version: "> 0.0.0"
-          - source: github.com/cloud-native-toolkit/terraform-vsi-argocd-bootstrap.git
-            version: "> 0.0.0"
-        optional: true
     variables:
       - name: gitops_config
         moduleRef:
@@ -65,5 +54,5 @@ versions:
           output: name
       - name: kubeseal_cert
         moduleRef:
-          id: argocd-bootstrap
+          id: gitops
           output: sealed_secrets_cert

--- a/test/stages/stage1-argocd-bootstrap.tf
+++ b/test/stages/stage1-argocd-bootstrap.tf
@@ -10,4 +10,6 @@ module "argocd-bootstrap" {
   git_username        = module.gitops.config_username
   git_token           = module.gitops.config_token
   bootstrap_path      = module.gitops.bootstrap_path
+  sealed_secret_cert  = module.cert.cert
+  sealed_secret_private_key = module.cert.private_key
 }

--- a/test/stages/stage1-cert.tf
+++ b/test/stages/stage1-cert.tf
@@ -1,0 +1,4 @@
+module "cert" {
+  source = "github.com/cloud-native-toolkit/terraform-util-sealed-secret-cert.git"
+
+}

--- a/test/stages/stage1-gitops.tf
+++ b/test/stages/stage1-gitops.tf
@@ -8,6 +8,7 @@ module "gitops" {
   token = var.git_token
   username = var.git_username
   gitops_namespace = var.gitops_namespace
+  sealed_secrets_cert  = module.cert.cert
 }
 
 resource null_resource gitops_output {

--- a/test/stages/stage1-namespace.tf
+++ b/test/stages/stage1-namespace.tf
@@ -4,8 +4,6 @@ module "gitops_namespace" {
   gitops_config = module.gitops.gitops_config
   git_credentials = module.gitops.git_credentials
   name = var.namespace
-  argocd_namespace       = module.argocd-bootstrap.argocd_namespace
-  argocd_service_account = module.argocd-bootstrap.argocd_service_account
   server_name              = module.gitops.server_name
 }
 

--- a/test/stages/stage2-sonarqube.tf
+++ b/test/stages/stage2-sonarqube.tf
@@ -4,9 +4,6 @@ module "gitops_sonarqube" {
   gitops_config            = module.gitops.gitops_config
   git_credentials          = module.gitops.git_credentials
   namespace                = module.gitops_namespace.name
-  cluster_ingress_hostname = module.dev_cluster.platform.ingress
-  cluster_type             = module.dev_cluster.platform.type_code
-  tls_secret_name          = module.dev_cluster.platform.tls_secret
-  kubeseal_cert            = module.argocd-bootstrap.sealed_secrets_cert
+  kubeseal_cert            = module.gitops.sealed_secrets_cert
   server_name              = module.gitops.server_name
 }


### PR DESCRIPTION
- Makes cluster dependency optional (only needed for IKS)
- Updates kubeseal_cert dependency satisfied by gitops repo instead of argocd bootstrap

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>